### PR TITLE
fix(ROCm): prevent early import of GFX950MXScaleLayout in mxfp4_utils…

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/mxfp4_utils.py
@@ -36,15 +36,15 @@ def _swizzle_mxfp4(quant_tensor, scale, num_warps):
         value_layout = StridedLayout
         scale_layout = StridedLayout
     elif current_platform.is_rocm():
-        from triton_kernels.tensor_details.layout import (
-            GFX950MXScaleLayout,
-            StridedLayout,
-        )
-
+        from triton_kernels.tensor_details.layout import StridedLayout
         from vllm.platforms.rocm import on_gfx950
 
         value_layout = StridedLayout
-        scale_layout = GFX950MXScaleLayout if on_gfx950() else StridedLayout
+        if on_gfx950():
+            from triton_kernels.tensor_details.layout import GFX950MXScaleLayout
+            scale_layout = GFX950MXScaleLayout
+        else:
+            scale_layout = StridedLayout
     else:
         value_layout, value_layout_opts = layout.make_default_matmul_mxfp4_w_layout(
             mx_axis=1


### PR DESCRIPTION
This pull request addresses an issue for users with legacy ROCm GPUs.
The file vllm/model_executor/layers/quantization/utils/mxfp4_utils.py was importing GFX950MXScaleLayout unconditionally, which caused an error on older hardware that doesn't support it.
I have modified the logic to only import it when on_gfx950() is true. This change allows vLLM to run successfully on older ROCm GPUs without affecting newer hardware.