### PR TITLE
Fix DSv4 k out of range error

### DIFF
--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -993,8 +993,9 @@ class DeepseekV4Indexer(nn.Module):
         self.quant_block_size = 128  # TODO: get from config
         self.topk_indices_buffer = topk_indices_buffer
 
-        self.max_model_len = (
-            vllm_config.model_config.max_model_len // self.compress_ratio
+        self.max_model_len = max(
+            vllm_config.model_config.max_model_len // self.compress_ratio,
+            self.topk_tokens,
         )
         self.prefix = prefix
 

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -318,7 +318,7 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
-        if current_platform.is_cuda() and topk_tokens in (512, 2048):
+        if current_platform.is_cuda() and topk_tokens in (512, 1024, 2048):
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),


### PR DESCRIPTION

## Purpose
When setting a small max-model-len, it crashes:
```
VLLM_ENGINE_READY_TIMEOUT_S=3600 vllm serve deepseek-ai/DeepSeek-V4-Pro \
--trust-remote-code \
--kv-cache-dtype fp8 \
--block-size 256 \
--no-enable-prefix-caching \
--enable-expert-parallel \
--data-parallel-size 8 \
--max-model-len 2304 \
--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE","custom_ops":["all"]}' \
--tokenizer-mode deepseek_v4 \
--tool-call-parser deepseek_v4 \
--enable-auto-tool-choice \
--reasoning-parser deepseek_v4
```

```
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1269, in __call__
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]     return self._op(*args, **kwargs)
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]   File "/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/sparse_attn_indexer.py", line 326, in sparse_attn_indexer
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]     torch.ops._C.persistent_topk(
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1269, in __call__
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]     return self._op(*args, **kwargs)
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_DP7_EP7 pid=1855948) ERROR 04-24 14:15:46 [multiproc_executor.py:971] RuntimeError: k out of range
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

