### PR TITLE
[DSV4][Bugfix] Apply swiglu_limit to DSV2 SharedExpert MLP

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -196,6 +196,7 @@ class DeepseekV2MLP(nn.Module):
         quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
         is_sequence_parallel=False,
+        swiglu_limit: float | None = None,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -226,9 +227,14 @@ class DeepseekV2MLP(nn.Module):
                 f"Unsupported activation: {hidden_act}. Only silu is supported for now."
             )
         self.act_fn = SiluAndMul()
+        self.swiglu_limit = swiglu_limit
 
     def forward(self, x):
         gate_up, _ = self.gate_up_proj(x)
+        if self.swiglu_limit is not None:
+            lim = float(self.swiglu_limit)
+            g, u = gate_up.chunk(2, dim=-1)
+            gate_up = torch.cat([g.clamp(max=lim), u.clamp(min=-lim, max=lim)], dim=-1)
         x = self.act_fn(gate_up)
         x, _ = self.down_proj(x)
         return x

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -167,6 +167,7 @@ class DeepseekV4MoE(nn.Module):
                 hidden_act=config.hidden_act,
                 quant_config=quant_config,
                 reduce_results=False,
+                swiglu_limit=self.swiglu_limit,
                 prefix=f"{prefix}.shared_experts",
             )
 


### PR DESCRIPTION
BUGFIX FOR CRITICAL DSV4-PRO ACCURACY ISSUE

For details, see: https://github.com/sgl-project/sglang/pull/23776

Reproducer:

```
curl -s http://localhost:8811/v1/chat/completions -H "Content-Type: application/json" -d '{"model":"deepseek-ai/DeepSeek-V4-Pro","messages":[{"role":"user","content":"Which are the three longest rivers mentioned in the Aeneid?"}],"temperature":1.0,"max_tokens":256,"chat_template_kwargs":{"thinking":true}}'
```

Expected (fixed) output:

```
{"id":"chatcmpl-8df71c5c60342d4a","object":"chat.completion","created":1777245323,"model":"deepseek-ai/DeepSeek-V4-Pro","choices":[{"index":0,"message":{"role":"assistant","content":null,"refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":"We need to find the three longest rivers mentioned in the Aeneid. The Aeneid is an epic poem by Virgil. The question asks for the three longest rivers mentioned. \"Longest\" could refer to the physical length of the rivers in real-world geography. The poem mentions various rivers: Tiber (The three longest rivers mentioned in Virgil’s *Aeneid* are:\n\n  \n\n1. **Danube (Ister/Hister)** – Longest river in the Roman world;and** Europe; mentioned in prophecies about Rome’s future extent (*Aeneid* 1.452–493, where Jupiter foretells empire stretching to the “mouths of the sevenfold Danube”).\n2. **Euphrates** – East of Rome, often referenced as a limit of Roman power (*Aeneid* 8.726, on Aeneas’ shield, showing the conquered Euphrates flowing more gently). By length it is the longest river in Western Asia.\n3. **Nile** – The longest river in Africa; appears multiple times, notably in 8.711–713 (the personified Nile on the shield) and 10.976–977 (Tiberinus mentioning the sevenfold Nile).\n\nThese three are frequently"},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,
```

Expected (bad) output:

```
{"id":"chatcmpl-bc44d3227818f0eb","object":"chat.completion","created":1777243955,"model":"deepseek-ai/DeepSeek-V4-Pro","choices":[{"index":0,"message":{"role":"assistant","content":null,"refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning":"We need to find the three longest rivers mentioned in the Aeneid. The Aeneid is an epic poem by Virgil. The question asks for the three longest rivers mentioned. \"Longest\"571Rivers likely refers to15physical length15in the real world, though56since it's701Latin myth, they771might be referring to geographic rivers. Need to14identify rivers mentioned in the Aeneid and then rank them by length. The20longest rivers in the world: Nile (longest), Amazon, Yangtze, Mississippi-Missouri, Yenisei, Yellow, Ob-Irtysh, etc. But the Aeneid06mentions rivers within the context of the ancient Mediterranean world, particularly those12known to Romans.109Rivers mentioned in the Aeneid:27Tiber (major setting317Italian7river),251Po (Eridanus,87often mentioned),61Danube (Ister or Danuvius,809maybe),22Rhine, Rhone,698Nile (Nilus,891mentioned in connection with Egypt95and Cleopatra,50Antony),04Simois,41Scamander (Xanthus) in Troy,10Lethe (mythical, not real"},"logprobs":null,"finish_reason":"length","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":17,"total_tokens":273,"completion_tokens":256,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null}
```