### PR TITLE
Sanitize unfilled recv slots in flashinfer_nvlink_one_sided dispatch

### DIFF
--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -114,6 +114,7 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
         payloads.append(a1q)
         if a1q_scale is not None:
             payloads.append(a1q_scale)
+        topk_ids_payload_index = len(payloads)
         payloads.append(topk_ids)
         payloads.append(topk_weights)
 
@@ -122,6 +123,8 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
             token_selected_experts=topk_ids,
             input_payloads=payloads,
             runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
+            invalid_token_expert_id=num_experts,
+            expert_id_payload_index=topk_ids_payload_index,
         )
         if a1q_scale is not None:
             a1q_recv, a1q_scale_recv, topk_ids_recv, topk_weights_recv = recv_payloads


### PR DESCRIPTION
Padded rows in the `[ep_size, max_num_tokens, ...]` workspace retain
stale `topk_ids` from prior dispatch calls (the workspace is zeroed
only once at init). Those stale ids cause the downstream `trtllm_fp4`
grouped GEMM to do phantom work for random local experts every layer,
which (a) inflates expert GEMM time and (b) creates the cross-rank
skew that the combine kernel then has to wait on.

Setting `invalid_token_expert_id` to `num_experts` (one past the valid
expert range) makes the flashinfer worker overwrite all `top_k`
`topk_ids` slots of padded rows with that sentinel
(`moeA2ASanitizeExpertIdsKernel` in `moeAlltoAllKernels.cu`); the
trtllm grouped GEMM then sees those rows as routed to no local expert
(out of `[local_expert_offset, local_expert_offset + local_num_experts)`)
and skips them.